### PR TITLE
Use Result instead of unwrap in get-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,12 +894,12 @@ dependencies = [
 name = "get-config"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "azure_core",
  "azure_identity",
  "azure_security_keyvault",
  "azure_svc_appconfiguration",
  "clap",
+ "color-eyre",
  "futures",
  "serde",
  "serde_json",

--- a/src/get-config/Cargo.toml
+++ b/src/get-config/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.75"
 azure_core = "0.16.0"
 azure_identity = "0.16.1"
 azure_security_keyvault = "0.16.0"
 azure_svc_appconfiguration = { version = "0.16.0", features = ["package-2019-07"] }
+color-eyre = "0.6.2"
 clap = { version = "4.4.6", features = ["derive"] }
 futures = "0.3.28"
 serde = { version = "1.0.188", features = ["derive"] }


### PR DESCRIPTION
I believe this is the preferred approach in Rust code. This also switches to color-eyre in get-config so that if it does panic, it panics with color 